### PR TITLE
Fix blank screen by configuring PrimeNG theme

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -10,6 +10,8 @@ import { provideHttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { providePrimeNG } from 'primeng/config';
+import Lara from '@primeuix/themes/lara';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -18,6 +20,11 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(),
     provideAnimations(),
+    providePrimeNG({
+      theme: {
+        preset: Lara,
+      },
+    }),
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
-import { usePreset } from '@primeuix/themes';
-import Lara from '@primeuix/themes/lara';
-
-usePreset(Lara);
-
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- configure PrimeNG with Lara preset via providePrimeNG
- remove direct `usePreset` call and bootstrap normally

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_688fe4d193088322b8e72bac4304fa07